### PR TITLE
Auto select current word if none selected

### DIFF
--- a/src/RcStrings.VsPackage/RcStringsPackage.cs
+++ b/src/RcStrings.VsPackage/RcStringsPackage.cs
@@ -176,6 +176,9 @@ namespace Caphyon.RcStrings.VsPackage
     private void UpdateQueryWord()
     {
       if (EditorSelection.IsEmpty)
+        mDte.ExecuteCommand("Edit.SelectCurrentWord");
+
+      if (EditorSelection.IsEmpty)
       {
         // Detect the query word if nothing is selected.
         mSelectedWord = string.Empty;


### PR DESCRIPTION
makes editing RC strings easier because no longer requires the user to select the word